### PR TITLE
Add API endpoints for IPFS and Vault modules

### DIFF
--- a/docs/api-reference/ipfs/api/1.mdx
+++ b/docs/api-reference/ipfs/api/1.mdx
@@ -1,0 +1,5 @@
+---
+title: Add File
+api: GET /sonr-io/highway/ipfs/add
+description: Add a file to the IPFS Network with the Sonr gateway
+---

--- a/docs/api-reference/ipfs/api/2.mdx
+++ b/docs/api-reference/ipfs/api/2.mdx
@@ -1,0 +1,5 @@
+---
+title: Check Exists
+api: GET /sonr-io/highway/ipfs/exists
+description: Check if a provided CID hash exists in the IPFS network.
+---

--- a/docs/api-reference/ipfs/api/3.mdx
+++ b/docs/api-reference/ipfs/api/3.mdx
@@ -1,0 +1,5 @@
+---
+title: Get File
+api: GET /sonr-io/highway/ipfs/get
+description: Get content from a given IPFS hash
+---

--- a/docs/api-reference/ipfs/overview.mdx
+++ b/docs/api-reference/ipfs/overview.mdx
@@ -1,0 +1,6 @@
+---
+title: "IPFS Overview"
+sidebarTitle: "Overview"
+---
+
+The IPFS module is part of the Sonr Highway protocol. It is responsible for establishing a gateway to the IPFS network, and for providing a way to access IPFS content from the Sonr Highway network.

--- a/docs/api-reference/vault/api/1.mdx
+++ b/docs/api-reference/vault/api/1.mdx
@@ -1,0 +1,5 @@
+---
+title: Get Challenge
+api: GET /sonr-io/highway/vault/challenge
+description: Fetches a challenge to be signed for WebAuthn
+---

--- a/docs/api-reference/vault/api/2.mdx
+++ b/docs/api-reference/vault/api/2.mdx
@@ -1,0 +1,5 @@
+---
+title: Register Device
+api: POST /sonr-io/highway/vault/register
+description: Register a device with a VerificationMethod for the Sonr Vault.
+---

--- a/docs/api-reference/vault/api/3.mdx
+++ b/docs/api-reference/vault/api/3.mdx
@@ -1,0 +1,5 @@
+---
+title: Generate Account
+api: POST /sonr-io/highway/vault/keygen
+description: Initialize a P2P Multi-Party Computation (MPC) session for a new root account.
+---

--- a/docs/api-reference/vault/api/4.mdx
+++ b/docs/api-reference/vault/api/4.mdx
@@ -1,0 +1,5 @@
+---
+title: Sign Transaction
+api: POST /sonr-io/highway/vault/sign
+description: Utilize the MPC Protocol to sign a transaction
+---

--- a/docs/api-reference/vault/api/5.mdx
+++ b/docs/api-reference/vault/api/5.mdx
@@ -1,0 +1,5 @@
+---
+title: Derive Wallet
+api: POST /sonr-io/highway/vault/derive
+description: Create a new path for a wallet and derive a new address
+---

--- a/docs/api-reference/vault/api/6.mdx
+++ b/docs/api-reference/vault/api/6.mdx
@@ -1,0 +1,5 @@
+---
+title: Refresh Account
+api: POST /sonr-io/highway/vault/refresh
+description: Refresh an account's Wallet Shares while keeping the same account ID.
+---

--- a/docs/api-reference/vault/overview.mdx
+++ b/docs/api-reference/vault/overview.mdx
@@ -1,0 +1,6 @@
+---
+title: "Vault Overview"
+sidebarTitle: "Overview"
+---
+
+The Vault module is part of the Sonr Highway protocol. Vault is responsible for providing a secure P2P storage solution for the Sonr Highway protocol. It is a decentralized storage solution that allows users to store data in a secure and private manner. The Vault module is responsible for storing data in a decentralized manner and providing a secure storage solution for the Sonr Highway protocol.


### PR DESCRIPTION
Added five new API endpoints for the IPFS and Vault modules of the Sonr Highway protocol. These endpoints provide access to the IPFS network and allow users to securely store data in a decentralized manner.

Closes SNR-13